### PR TITLE
Update Readme to include theme install location

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Themes in this repository are the **source assets** used directly by the device 
 
 ## Installing Pager Themes
 
-To install a new theme, simply copy it to `/root/themes/`, or `/mmc/root/themes/`.
+To install a new theme, simply copy it to `/root/themes/`, or `/mmc/root/themes/` (Create the `themes` directory if it doesn't exist yet).
 
 ## Contributing Themes
 


### PR DESCRIPTION
I may just have missed it, but I don't think the docs actually state the theme install location anywhere!